### PR TITLE
Add `usbutils` package

### DIFF
--- a/cupsd/Dockerfile
+++ b/cupsd/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
 && apt-get install -y \
   sudo \
   whois \
+  usbutils \
   cups \
   cups-client \
   cups-bsd \


### PR DESCRIPTION
Provides `lsusb` which is useful for sorting issues with device sharing (e.g. for rootless/OCI setups)