### PR TITLE
Update images using Java for Debian 12

### DIFF
--- a/bazel/Dockerfile
+++ b/bazel/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 && apt-get install -y \
   gpg \
   curl \
-  openjdk-11-jdk \
+  default-jdk \
 && echo "deb http://storage.googleapis.com/bazel-apt stable jdk1.8" \
   > /etc/apt/sources.list.d/bazel.list \
 && curl https://bazel.build/bazel-release.pub.gpg | apt-key add - \

--- a/java-devel/Dockerfile
+++ b/java-devel/Dockerfile
@@ -27,7 +27,7 @@ RUN useradd \
 && sed -i '/%sudo[[:space:]]/ s/ALL[[:space:]]*$/NOPASSWD:ALL/' /etc/sudoers
 
 # Setup environment
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 RUN /bin/echo -e "export JAVA_HOME=${JAVA_HOME}" >> /home/java/.bashrc
 USER java
 WORKDIR /home/java

--- a/libreoffice/Dockerfile
+++ b/libreoffice/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
 && apt-get install -y \
   sudo \
   curl \
-  openjdk-11-jre \
+  openjdk-17-jre \
   libreoffice-help-en-us \
   hunspell-en-us \
   mythes-en-us \
@@ -17,7 +17,7 @@ RUN apt-get update \
 && rm -rf /var/lib/apt/lists/*
 
 # Configure Java Env. (see https://wiki.debian.org/LibreOffice#Java_Environment)
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 
 # Install LanguageTool extension
 

--- a/libreoffice/Dockerfile.i18n
+++ b/libreoffice/Dockerfile.i18n
@@ -25,7 +25,7 @@ Pin-Priority: -100\n'\
 && apt-get install -y \
   sudo \
   curl \
-  openjdk-11-jre \
+  openjdk-17-jre \
   "libreoffice-l10n-*" \
   "libreoffice-help-*" \
   "hunspell-*" \
@@ -36,7 +36,7 @@ Pin-Priority: -100\n'\
 && rm -rf /var/lib/apt/lists/*
 
 # Configure Java Env. (see https://wiki.debian.org/LibreOffice#Java_Environment)
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+ENV JAVA_HOME /usr/lib/jvm/java-17-openjdk-amd64
 
 # FIXME: temporary disabled because of an error similar to this one:
 #         https://github.com/hanya/MRI/issues/11


### PR DESCRIPTION
The default Java version has changed to OpenJDK 17 (updated from 11) in Debian 12, which is now the base for most of the images.

This change upgrades the images to use the appropriate version of OpenJDK (using the default one when possible).