### PR TITLE
Add ports to use for docker files

### DIFF
--- a/cupsd/Dockerfile
+++ b/cupsd/Dockerfile
@@ -23,6 +23,9 @@ RUN apt-get update \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 
+# This will use port 631
+EXPOSE 631
+
 # Add user and disable sudo password checking
 RUN useradd \
   --groups=sudo,lp,lpadmin \

--- a/cupsd/Dockerfile.stable
+++ b/cupsd/Dockerfile.stable
@@ -23,6 +23,9 @@ RUN apt-get update \
 && apt-get clean \
 && rm -rf /var/lib/apt/lists/*
 
+# This will use port 631
+EXPOSE 631
+
 # Add user and disable sudo password checking
 RUN useradd \
   --groups=sudo,lp,lpadmin \


### PR DESCRIPTION
When creating a docker container, selecting a network as host conflicts with the system port and cannot be used. Therefore, we specified the port in the dockerfile.