### PR TITLE
Allow remote Access without "bad request"

### DIFF
--- a/cupsd/cupsd.conf
+++ b/cupsd/cupsd.conf
@@ -16,6 +16,7 @@ ErrorPolicy retry-job
 
 # Allow remote access
 Listen *:631
+ServerAlias *
 
 # Show shared printers on the local network.
 Browsing Yes


### PR DESCRIPTION
In my installation, the call always failed due to an HTTP error “Bad Request”. Adding the ServerAlias line (as described in https://www.ugg.li/cups-meldet-bad-request-bei-ssl-auf-ipfqdn/ ) solved the problem.