### PR TITLE
Fix: update config files for light ImageMagick image

### DIFF
--- a/imagemagick/Dockerfile.light
+++ b/imagemagick/Dockerfile.light
@@ -21,42 +21,83 @@ COPY --from=base \
 COPY --from=base /lib64/ld-linux-x86-64.so.2  /lib64/ld-linux-x86-64.so.2 
 
 COPY --from=base \
-	/usr/lib/x86_64-linux-gnu/ImageMagick-6.9.11/modules-Q16/coders/*.so \
+	/usr/lib/x86_64-linux-gnu/ImageMagick-7.1.1/modules-Q16/coders/*.so \
 	/lib/
 
 COPY --from=base \
+	/lib/x86_64-linux-gnu/libIex-3_1.so.30  \
+	/lib/x86_64-linux-gnu/libIlmThread-3_1.so.30  \
+	/lib/x86_64-linux-gnu/libImath-3_1.so.29  \
+	/lib/x86_64-linux-gnu/libLerc.so.4  \
 	/lib/x86_64-linux-gnu/libMagickCore-7.Q16.so.10  \
 	/lib/x86_64-linux-gnu/libMagickWand-7.Q16.so.10  \
+	/lib/x86_64-linux-gnu/libOpenEXR-3_1.so.30  \
+	/lib/x86_64-linux-gnu/libOpenEXRCore-3_1.so.30  \
 	/lib/x86_64-linux-gnu/libX11.so.6  \
 	/lib/x86_64-linux-gnu/libXau.so.6  \
 	/lib/x86_64-linux-gnu/libXdmcp.so.6  \
 	/lib/x86_64-linux-gnu/libXext.so.6  \
+	/lib/x86_64-linux-gnu/libXrender.so.1  \
 	/lib/x86_64-linux-gnu/libatomic.so.1  \
+	/lib/x86_64-linux-gnu/libblkid.so.1  \
 	/lib/x86_64-linux-gnu/libbrotlicommon.so.1  \
 	/lib/x86_64-linux-gnu/libbrotlidec.so.1  \
 	/lib/x86_64-linux-gnu/libbz2.so.1.0  \
 	/lib/x86_64-linux-gnu/libc.so.6  \
+	/lib/x86_64-linux-gnu/libcairo.so.2  \
+	/lib/x86_64-linux-gnu/libdatrie.so.1  \
+	/lib/x86_64-linux-gnu/libdeflate.so.0  \
+	/lib/x86_64-linux-gnu/libdjvulibre.so.21  \
 	/lib/x86_64-linux-gnu/libexpat.so.1  \
+	/lib/x86_64-linux-gnu/libffi.so.8  \
 	/lib/x86_64-linux-gnu/libfftw3.so.3  \
 	/lib/x86_64-linux-gnu/libfontconfig.so.1  \
 	/lib/x86_64-linux-gnu/libfreetype.so.6  \
+	/lib/x86_64-linux-gnu/libfribidi.so.0  \
 	/lib/x86_64-linux-gnu/libgcc_s.so.1  \
+	/lib/x86_64-linux-gnu/libgio-2.0.so.0  \
 	/lib/x86_64-linux-gnu/libglib-2.0.so.0  \
+	/lib/x86_64-linux-gnu/libgmodule-2.0.so.0  \
+	/lib/x86_64-linux-gnu/libgobject-2.0.so.0  \
 	/lib/x86_64-linux-gnu/libgomp.so.1  \
+	/lib/x86_64-linux-gnu/libgraphite2.so.3  \
+	/lib/x86_64-linux-gnu/libharfbuzz.so.0  \
+	/lib/x86_64-linux-gnu/libheif.so.1  \
+	/lib/x86_64-linux-gnu/libjbig.so.0  \
+	/lib/x86_64-linux-gnu/libjpeg.so.62  \
 	/lib/x86_64-linux-gnu/liblcms2.so.2  \
 	/lib/x86_64-linux-gnu/liblqr-1.so.0  \
 	/lib/x86_64-linux-gnu/libltdl.so.7  \
 	/lib/x86_64-linux-gnu/liblzma.so.5  \
 	/lib/x86_64-linux-gnu/libm.so.6  \
+	/lib/x86_64-linux-gnu/libmount.so.1  \
+	/lib/x86_64-linux-gnu/libopenjp2.so.7  \
+	/lib/x86_64-linux-gnu/libpango-1.0.so.0  \
+	/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0  \
+	/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0  \
 	/lib/x86_64-linux-gnu/libpcre2-8.so.0  \
+	/lib/x86_64-linux-gnu/libpixman-1.so.0  \
 	/lib/x86_64-linux-gnu/libpng16.so.16  \
+	/lib/x86_64-linux-gnu/libraw_r.so.23  \
+	/lib/x86_64-linux-gnu/libselinux.so.1  \
+	/lib/x86_64-linux-gnu/libsharpyuv.so.0  \
+	/lib/x86_64-linux-gnu/libstdc++.so.6  \
+	/lib/x86_64-linux-gnu/libthai.so.0  \
+	/lib/x86_64-linux-gnu/libtiff.so.6  \
+	/lib/x86_64-linux-gnu/libwebp.so.7  \
+	/lib/x86_64-linux-gnu/libwebpdemux.so.2  \
+	/lib/x86_64-linux-gnu/libwebpmux.so.3  \
+	/lib/x86_64-linux-gnu/libwmflite-0.2.so.7  \
+	/lib/x86_64-linux-gnu/libxcb-render.so.0  \
+	/lib/x86_64-linux-gnu/libxcb-shm.so.0  \
 	/lib/x86_64-linux-gnu/libxcb.so.1  \
 	/lib/x86_64-linux-gnu/libxml2.so.2  \
 	/lib/x86_64-linux-gnu/libz.so.1  \
+	/lib/x86_64-linux-gnu/libzstd.so.1  \
 	/lib/
 
-COPY --from=base /usr/lib/x86_64-linux-gnu/ImageMagick-6.9.11 /usr/lib/x86_64-linux-gnu/ImageMagick-6.9.11
-COPY --from=base /etc/ImageMagick-6 /etc/ImageMagick-6
-COPY --from=base /usr/share/ImageMagick-6 /usr/share/ImageMagick-6
+COPY --from=base /usr/lib/x86_64-linux-gnu/ImageMagick-7.1.1 /usr/lib/x86_64-linux-gnu/ImageMagick-7.1.1
+COPY --from=base /etc/ImageMagick-7 /etc/ImageMagick-7
+COPY --from=base /usr/share/ImageMagick-7 /usr/share/ImageMagick-7
 
 CMD ["/usr/bin/identify"]

--- a/imagemagick/gen-light.env
+++ b/imagemagick/gen-light.env
@@ -1,4 +1,4 @@
 BASEIMAGE="olbat/imagemagick"
 EXECUTABLES="/usr/bin/identify /usr/bin/mogrify /usr/bin/montage /usr/bin/display /usr/bin/stream /usr/bin/import /usr/bin/conjure /usr/bin/composite /usr/bin/convert /usr/bin/animate /usr/bin/compare"
-SHARED_LIBRARIES="/usr/lib/x86_64-linux-gnu/ImageMagick-6.9.11/modules-Q16/coders/*.so"
-FILES="/usr/lib/x86_64-linux-gnu/ImageMagick-6.9.11 /etc/ImageMagick-6 /usr/share/ImageMagick-6"
+SHARED_LIBRARIES="/usr/lib/x86_64-linux-gnu/ImageMagick-7.1.1/modules-Q16/coders/*.so"
+FILES="/usr/lib/x86_64-linux-gnu/ImageMagick-7.1.1 /etc/ImageMagick-7 /usr/share/ImageMagick-7"


### PR DESCRIPTION
The image doesn't build on the latest Debian stable as the major version of ImageMagick changed to v7.