### PR TITLE
Fix: escape special character '[' in COPY command of sak:light image

### DIFF
--- a/sak/Dockerfile.light
+++ b/sak/Dockerfile.light
@@ -48,7 +48,7 @@ COPY --from=base \
 	/bin/umount \
 	/bin/uname \
 	/bin/vdir \
-	/usr/bin/[ \
+	/usr/bin/[[] \
 	/usr/bin/addr2line \
 	/usr/bin/ar \
 	/usr/bin/arch \


### PR DESCRIPTION
This special character needs to be escaped to prevent Kaniko builds from failing, see https://docs.docker.com/reference/dockerfile/#copy for the escape sequence.