### PR TITLE
Remove printer-driver-gutenprint from cupsd image

### DIFF
--- a/cupsd/Dockerfile
+++ b/cupsd/Dockerfile
@@ -49,7 +49,6 @@ RUN apt-get update \
   printer-driver-sag-gdi \
   printer-driver-splix \
   printer-driver-cups-pdf \
-  printer-driver-gutenprint \
   smbclient \
   avahi-utils \
 && apt-get clean \


### PR DESCRIPTION
The printer-driver-gutenprint package has been removed from Debian testing, removing it from the image.