### PR TITLE
Fix cupsd web admin "Unauthorized" by listening on local domain socket

### DIFF
--- a/cupsd/cupsd.conf
+++ b/cupsd/cupsd.conf
@@ -16,6 +16,11 @@ ErrorPolicy retry-job
 
 # Allow remote access
 Listen *:631
+# Listen on the local domain socket too: the web interface CGIs opens
+# a privileged back-channel to cupsd over this socket. Without it
+# admin actions fail with "Unauthorized" even with correct credentials.
+# See https://github.com/olbat/dockerfiles/issues/151
+Listen /run/cups/cups.sock
 ServerAlias *
 
 # Show shared printers on the local network.


### PR DESCRIPTION
The CUPS web interface runs admin operations (e.g. Add Printer) through a CGI that opens a privileged back-channel to cupsd over the local UNIX domain socket /run/cups/cups.sock. The bundled cupsd.conf only had "Listen *:631" and was missing the socket listener that Debian's stock config ships by default, so the CGI fell back to TCP without credentials and cupsd returned 401 Unauthorized -- surfaced in the browser as a failed login regardless of the password.

Restore "Listen /run/cups/cups.sock" so admin actions work with the print/print credentials.

Fixes #151